### PR TITLE
fix repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/config-plugins.git",
-    "directory": "packages/expo-privacy-manifest-polyfill-plugin"
+    "url": "https://github.com/expo/expo-privacy-manifest-polyfill-plugin.git"
   },
   "scripts": {
     "build": "expo-module build",


### PR DESCRIPTION
Without this fix the link to the package's entry on [NPM](https://www.npmjs.com/package/expo-privacy-manifest-polyfill-plugin) navigates to the wrong project on GitHub.