### PR TITLE
Update readme to clarify how polyfill uses same config as SDK 50+

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Next, rebuild your app as described in the ["Adding custom native code"](https:/
 
 Use the `NSPrivacyAccessedAPIType` and `NSPrivacyAccessedAPITypeReasons` values listed in https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.
 
+Include these values under `ios.privacyManifests` in your **app.json** / **app.config.js**. The config plugin does not accept any parameters itself. Rather, it reads the privacy values from `ios.privacyManifests` and uses these to create an embed a **PrivacyInfo.xcprivacy** file in your native project during Prebuild.
+
 ```json
 {
   "expo": {
@@ -51,3 +53,6 @@ Use the `NSPrivacyAccessedAPIType` and `NSPrivacyAccessedAPITypeReasons` values 
   }
 }
 ```
+
+## Upgrading to SDK 50+
+Once you upgrade your project to SDK 50 or higher, the plugin integrated into `@expo/config-plugins` handles this automatically. You can remove `expo-privacy-manifest-polyfill-plugin` from your dependencies and from the `plugins` array in your app config. Leave any needed values in `ios.privacyManifests`, as SDK 50+'s plugin will use that same configuration.


### PR DESCRIPTION
It totally makes sense for this plugin, but I'm used to config plugins that take their own parameters rather than reading something else in app.config, so thought it might be good to add some extra clarification there (a sort of "don't adjust your monitor, that code example is correct" callout).

From there, a clarification as to what you do when upgrading seemed useful, as well. Just some extra reinforcement that the configuration remains the same, it's just that the polyfill can be removed.